### PR TITLE
Simplifying extraLuaPackages

### DIFF
--- a/nix/mkNeovim.nix
+++ b/nix/mkNeovim.nix
@@ -17,8 +17,10 @@ with lib;
     # e.g. [ "^plugin/neogit.lua" "^ftplugin/.*.lua" ]
     ignoreConfigRegexes ? [],
     extraPackages ? [], # Extra runtime dependencies (e.g. ripgrep, ...)
-    extraLuaPackages ? ps: [], # Additional lua packages (not plugins), e.g. from luarocks.org
     # The below arguments can typically be left as their defaults
+    # Additional lua packages (not plugins), e.g. from luarocks.org.
+    # e.g. p: [p.jsregexp]
+    extraLuaPackages ? p: [],
     extraPython3Packages ? p: [], # Additional python 3 packages
     withPython3 ? true, # Build Neovim with Python 3 support?
     withRuby ? false, # Build Neovim with Ruby support?
@@ -157,13 +159,13 @@ with lib;
 
     # Native Lua libraries
     extraMakeWrapperLuaCArgs =
-      optionalString (resolvedExtraLuaPackages != []) ''
-        --suffix LUA_CPATH ";" "${concatMapStringsSep ";" luaPackages.getLuaCPath resolvedExtraLuaPackages}"'';
+      optionalString (resolvedExtraLuaPackages != [])
+      ''--suffix LUA_CPATH ";" "${concatMapStringsSep ";" luaPackages.getLuaCPath resolvedExtraLuaPackages}"'';
 
     # Lua libraries
     extraMakeWrapperLuaArgs =
-      optionalString (resolvedExtraLuaPackages != []) ''
-        --suffix LUA_PATH ";" "${concatMapStringsSep ";" luaPackages.getLuaPath resolvedExtraLuaPackages}"'';
+      optionalString (resolvedExtraLuaPackages != [])
+      ''--suffix LUA_PATH ";" "${concatMapStringsSep ";" luaPackages.getLuaPath resolvedExtraLuaPackages}"'';
 
     # wrapNeovimUnstable is the nixpkgs utility function for building a Neovim derivation.
     neovim-wrapped = pkgs.wrapNeovimUnstable pkgs.neovim-unwrapped (neovimConfig

--- a/nix/neovim-overlay.nix
+++ b/nix/neovim-overlay.nix
@@ -84,20 +84,12 @@ with final.pkgs.lib; let
     lua-language-server
     nil # nix LSP
   ];
-
-  # These are runtime lua dependencies.
-  extraLuaPackages = ps:
-    with ps; [
-      # LuaSnip dependency.
-      jsregexp
-    ];
 in {
   # This is the neovim derivation
   # returned by the overlay
   nvim-pkg = mkNeovim {
     plugins = all-plugins;
     inherit extraPackages;
-    inherit extraLuaPackages;
   };
 
   # This can be symlinked in the devShell's shellHook

--- a/nix/neovim-overlay.nix
+++ b/nix/neovim-overlay.nix
@@ -84,12 +84,20 @@ with final.pkgs.lib; let
     lua-language-server
     nil # nix LSP
   ];
+
+  # These are runtime lua dependencies.
+  extraLuaPackages = ps:
+    with ps; [
+      # LuaSnip dependency.
+      jsregexp
+    ];
 in {
   # This is the neovim derivation
   # returned by the overlay
   nvim-pkg = mkNeovim {
     plugins = all-plugins;
     inherit extraPackages;
+    inherit extraLuaPackages;
   };
 
   # This can be symlinked in the devShell's shellHook


### PR DESCRIPTION
This little PR simplify the way users can provide runtime lua dependencies (such as `jsregexp` for luasnip, provided as an example in the PR as well). I think that it can be useful as it is not easy to know how to construct `resolvedExtraLuaPackages` (I had to dig into the way home-manager and nixpkgs build neovim).

You can try this PR by using `:checkhealth`, the `jsregexp` dependency will be found by luasnip.

You can find the way it is implemented inside home-manager [here](https://github.com/nix-community/home-manager/blob/master/modules/programs/neovim.nix#L65).