### PR TITLE
fix: remove obsolete `syntax` command invocations

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -107,9 +107,3 @@ cmd.packadd('cfilter') -- Allows filtering the quickfix list with :cfdo
 
 -- let sqlite.lua (which some plugins depend on) know where to find sqlite
 vim.g.sqlite_clib_path = require('luv').os_getenv('LIBSQLITE')
-
--- this should be at the end, because
--- it causes neovim to source ftplugins
--- on the packpath when passing a file to the nvim command
-cmd.syntax('on')
-cmd.syntax('enable')


### PR DESCRIPTION
Closes #21 