### PR TITLE
fix: allow users to remove nvim/ subdirectories except nvim/lua

### DIFF
--- a/nix/mkNeovim.nix
+++ b/nix/mkNeovim.nix
@@ -97,11 +97,17 @@ with lib;
       '';
 
       installPhase = ''
-        cp -r after $out/after
-        rm -r after
         cp -r lua $out/lua
         rm -r lua
-        cp -r * $out/nvim
+        # Copy nvim/after only if it exists
+        if [ -d "after" ]; then
+            cp -r after $out/after
+            rm -r after
+        fi
+        # Copy rest of nvim/ subdirectories only if they exist
+        if [ ! -z "$(ls -A)" ]; then
+            cp -r -- * $out/nvim
+        fi
       '';
     };
 


### PR DESCRIPTION
If you *only* want to keep nvim/lua directory, as many configs do, the current nix setup craps out at install phase.

The problem lies in `*` glob wildcard expanding to nothing in `cp -r * $out/nvim` (plus assuming `nvim/after` exists)

I've added two simple if-checks, to verify that there is something to copy first - it seems to be working on my end™ + checked with shellcheck to avoid getting bitten with any bashisms.