### PR TITLE
fix: appName typo in mkNeovim

### DIFF
--- a/nix/mkNeovim.nix
+++ b/nix/mkNeovim.nix
@@ -33,9 +33,9 @@ with lib;
     # You probably don't want to create vi or vim aliases
     # if the appName is something different than "nvim"
     # Add a "vi" binary to the build output as an alias?
-    viAlias ? appName == null || appname == "nvim",
+    viAlias ? appName == null || appName == "nvim",
     # Add a "vim" binary to the build output as an alias?
-    vimAlias ? appName == null || appname == "nvim",
+    vimAlias ? appName == null || appName == "nvim",
   }: let
     # This is the structure of a plugin definition.
     # Each plugin in the `plugins` argument list can also be defined as this attrset


### PR DESCRIPTION
Hi, I tried to specify a custom appName in `nix/neovim-overlay.nix` and ran into some problems. However, I wasn't able to fix it entirely; namely, when running `nix run .`, the command could not correctly resolve to the right binary after I changed the name of the output flake package name; it kept looking for a `bin/nvim`. (Running `nix build .` correctly produced a `result/bin/customAppName` with the custom appName.) I worked around this by specifying an output flake `apps` field. However, eventually I would like to fix this without doing so.  This PR partially fixes this by fixing (what I think is) a minor typo, but I could not figure out the fix to the full problem.