### PR TITLE
fix: use pkgs-wrapNeovim for plugins and extra packages

### DIFF
--- a/nix/neovim-overlay.nix
+++ b/nix/neovim-overlay.nix
@@ -25,7 +25,7 @@ with final.pkgs.lib; let
   #   optional = <true|false>; # Default: false
   #   ...
   # }
-  all-plugins = with pkgs.vimPlugins; [
+  all-plugins = with pkgs-wrapNeovim.vimPlugins; [
     # plugins from nixpkgs go in here.
     # https://search.nixos.org/packages?channel=unstable&from=0&size=50&sort=relevance&type=packages&query=vimPlugins
     nvim-treesitter.withAllGrammars
@@ -83,7 +83,7 @@ with final.pkgs.lib; let
     which-key-nvim
   ];
 
-  extraPackages = with pkgs; [
+  extraPackages = with pkgs-wrapNeovim; [
     # language servers, etc.
     lua-language-server
     nil # nix LSP


### PR DESCRIPTION
Currently, the plugins and extra packages do not use the pinned nixpkgs. This means that `nix run` could possibly use different versions of packages than when using the configuration in an overlay.