### PR TITLE
Add nvim-dev package for fast local development in a dev shell

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,2 @@
+watch_file nix/*
 use flake . -Lv

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ git merge upstream/main --allow-unrelated-histories
 
 When your neovim setup is a nix derivation, editing your config
 demands a different workflow than you are used to without nix.
-Here is how I usually do it:
+A quick and easy way to test your changes:
 
 - Perform modifications and stage any new files[^2].
 - Run `nix run /path/to/neovim/#nvim`
@@ -273,24 +273,24 @@ Here is how I usually do it:
 This requires a rebuild of the `nvim` derivation, but has the advantage
 that if anything breaks, it's only broken during your test run.
 
-If you want an impure, but faster feedback loop,
-you can use `$XDG_CONFIG_HOME/$NVIM_APPNAME`[^3], where `$NVIM_APPNAME` 
-defaults to `nvim` if the `appName` attribute is not set 
+When developing locally you might want to have a faster feedback loop.
+Normally the whole Neovim configuration is copied into the store and 
+the wrapper which nix generates for the derivation calls `nvim`
+with `-u /nix/store/path/to/generated-init.lua`. 
+We can deactivate this behavior with `wrapRc = false`, so that the 
+config is loaded from `$XDG_CONFIG_HOME/$NVIM_APPNAME`[^3], where 
+`$NVIM_APPNAME` defaults to `nvim` if the `appName` attribute is not set 
 in the `mkNeovim` function.
+
+The Flake exposes a dev shell with a `nvim-dev` package. The lua configuration in `./nvim`
+is automatically symlinked to `~/.config/nvim-dev`.
+
+After activating the shell with `nix develop` or [nix-direnv](https://github.com/nix-community/nix-direnv)
+you can run Neovim with `nvim-dev` to automatically reload your lua configuration. All Nix changes still require a rebuild.
+
 
 [^3]: Assuming Linux. Refer to `:h initialization` for Darwin.
 
-This has one caveat: The wrapper which nix generates for the derivation
-calls `nvim` with `-u /nix/store/path/to/generated-init.lua`.
-So it won't source a local `init.lua` file.
-To work around this, you can put scripts in the `plugin` or `after/plugin` directory.
-
-> [!TIP]
->
-> If you are starting out, and want to test things without having to
-> stage or commit new files for changes to take effect,
-> you can remove the `.git` directory and re-initialize it (`git init`)
-> when you are done.
 
 ## :link: Alternative / similar projects
 

--- a/flake.nix
+++ b/flake.nix
@@ -51,10 +51,13 @@
           nil
           stylua
           luajitPackages.luacheck
+          nvim-dev
         ];
         shellHook = ''
           # symlink the .luarc.json generated in the overlay
           ln -fs ${pkgs.nvim-luarc-json} .luarc.json
+          # allow quick iteration of lua configs
+          ln -Tfns $PWD/nvim ~/.config/nvim-dev
         '';
       };
     in {

--- a/nix/mkNeovim.nix
+++ b/nix/mkNeovim.nix
@@ -36,6 +36,7 @@ with lib;
     viAlias ? appName == null || appName == "nvim",
     # Add a "vim" binary to the build output as an alias?
     vimAlias ? appName == null || appName == "nvim",
+    wrapRc ? true,
   }: let
     # This is the structure of a plugin definition.
     # Each plugin in the `plugins` argument list can also be defined as this attrset
@@ -195,7 +196,7 @@ with lib;
           + extraMakeWrapperLuaCArgs
           + " "
           + extraMakeWrapperLuaArgs;
-        wrapRc = true;
+        wrapRc = wrapRc;
       });
 
     isCustomAppName = appName != null && appName != "nvim";

--- a/nix/neovim-overlay.nix
+++ b/nix/neovim-overlay.nix
@@ -96,6 +96,16 @@ in {
     inherit extraPackages;
   };
 
+  # This is meant to be used within a devshell.
+  # Instead of loading the lua Neovim configuration from
+  # the Nix store, it is loaded from $XDG_CONFIG_HOME/nvim-dev
+  nvim-dev = mkNeovim {
+    plugins = all-plugins;
+    inherit extraPackages;
+    appName = "nvim-dev";
+    wrapRc = false;
+  };
+
   # This can be symlinked in the devShell's shellHook
   nvim-luarc-json = final.mk-luarc-json {
     plugins = all-plugins;


### PR DESCRIPTION
I modified the README section about local development to include an example shell config, that allows fast local development inside a Nix shell.

I also updated `.envrc` to include the other nix files. This ensures that Direnv automatically rebuilds the local shell if a plugin is added or removed.

Related: https://github.com/nix-community/kickstart-nix.nvim/discussions/11 