### PR TITLE
Changed extension of sqlite shared library path based on platform

### DIFF
--- a/nix/mkNeovim.nix
+++ b/nix/mkNeovim.nix
@@ -156,7 +156,10 @@ with lib;
       '';
 
     # Add arguments to the Neovim wrapper script
-    extraMakeWrapperArgs = builtins.concatStringsSep " " (
+    extraMakeWrapperArgs = let
+      sqliteLibExt = if stdenv.isDarwin then ".dylib" else ".so";
+      sqliteLibPath = "${sqlite.out}/lib/libsqlite3${sqliteLibExt}";
+    in builtins.concatStringsSep " " (
       # Set the NVIM_APPNAME environment variable
       (optional (appName != "nvim" && appName != null && appName != "")
         ''--set NVIM_APPNAME "${appName}"'')
@@ -165,10 +168,10 @@ with lib;
         ''--prefix PATH : "${makeBinPath externalPackages}"'')
       # Set the LIBSQLITE_CLIB_PATH if sqlite is enabled
       ++ (optional withSqlite
-        ''--set LIBSQLITE_CLIB_PATH "${sqlite.out}/lib/libsqlite3.so"'')
+        ''--set LIBSQLITE_CLIB_PATH "${sqliteLibPath}"'')
       # Set the LIBSQLITE environment variable if sqlite is enabled
       ++ (optional withSqlite
-        ''--set LIBSQLITE "${sqlite.out}/lib/libsqlite3.so"'')
+        ''--set LIBSQLITE "${sqliteLibPath}"'')
     );
 
     luaPackages = neovim-unwrapped.lua.pkgs;


### PR DESCRIPTION
Plugins depending on SQLite were failing to load on Darwin due to the platform-specific shared library extension. This change updates the path to the SQLite shared library to conditionally use the appropriate extension based on the target platform.